### PR TITLE
remove forwardPoolErrors

### DIFF
--- a/src/hashpool.ts
+++ b/src/hashpool.ts
@@ -47,8 +47,6 @@ export default class HashPool extends EventEmitter {
 			socketTimeout: 100,
 		}, opts );
 
-		this.opts.forwardPoolErrors = true;
-
 		// initialize hash pool
 		for ( const node of nodes ) {
 			this.connect( node );


### PR DESCRIPTION
instead of needing to explicitly set forwardPoolErrors, always forward errors if there's a listener. We don't want to forward errors unconditionally because it counts as an uncaught error if there is no listener.